### PR TITLE
Use alpine in cloc image for smaller image size

### DIFF
--- a/cloc/Dockerfile
+++ b/cloc/Dockerfile
@@ -1,9 +1,7 @@
-FROM debian:jessie
+FROM alpine
 MAINTAINER Marcio Ribeiro <binary@b1n.org>
 
-RUN apt-get update && apt-get install -y \
-  cloc \
-  --no-install-recommends
+RUN apk add cloc --no-cache
 
 WORKDIR /data
 VOLUME "/data"


### PR DESCRIPTION
This uses the latest version of cloc available in apk which seems to be 1.76 at the moment.